### PR TITLE
Add share button to share current configuration

### DIFF
--- a/composables/webapis.ts
+++ b/composables/webapis.ts
@@ -63,19 +63,23 @@ export const useTestWebApis = (webApis?: WebApi[], force = false) => {
     for (const [key, val] of Object.entries(decodeStatus(sharedStatus.split('-')[1]))) {
       webApiStatuses.value[key] = val
     }
-  } else if (navigator) {
-    console.log('Testing capabilities...')
-    webApis = webApis || useWebApiList().value
-    webApis.forEach((webApi) => {
-      if (force || !webApiStatuses.value[webApi.id]) {
-        const check = webApi.check || defaultWebApiCheck
-        if (check.constructor.name === 'AsyncFunction') {
-          (check(webApi) as Promise<boolean>)
-            .then((available: boolean) => webApiStatuses.value[webApi.id] = available)
-        } else {
-          webApiStatuses.value[webApi.id] = check(webApi) as boolean
-        }
-      }
-    })
+    return true
   }
+  onMounted(() => {
+    if (navigator) {
+      console.log('Testing capabilities...')
+      webApis = webApis || useWebApiList().value
+      webApis.forEach((webApi) => {
+        if (force || !webApiStatuses.value[webApi.id]) {
+          const check = webApi.check || defaultWebApiCheck
+          if (check.constructor.name === 'AsyncFunction') {
+            (check(webApi) as Promise<boolean>)
+              .then((available: boolean) => webApiStatuses.value[webApi.id] = available)
+          } else {
+            webApiStatuses.value[webApi.id] = check(webApi) as boolean
+          }
+        }
+      })
+    }
+  })
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -85,8 +85,7 @@ const totalAPICount = computed(() => webApiList.value.length)
 function updateMode(newValue: DisplayMode) {
   displayMode.value = newValue
 }
-
-onMounted(() => useTestWebApis())
+useTestWebApis()
 
 watch(() => displayMode.value, (newVal, oldVal) => {
   console.log(`DisplayMode changed from '${oldVal}' to '${newVal}'`)


### PR DESCRIPTION
Fixes #20

- I've added the webApiExportList and the test to check if every api is present in the array
- I've also added the encode and decode functions to encode and decode the current configuration into a number
- I've added the share page that is similar to index but with uses the query param to populate the cards (i've also moved the code to a shared component to facilitate future modification to the template)
- I've added the share button on top of the index page that opens a modal to copy the sharable url

Things i'd like to finish before merging:

- I would like to add a github action to run tests on new pr
- Figure out what to do when we click from the share page on an api card